### PR TITLE
Adding functionality to export and import multi-t1 cgws

### DIFF
--- a/config_ini/config.ini
+++ b/config_ini/config.ini
@@ -55,10 +55,16 @@ nsx_adv_fw_export = False
 # Export the multiple tier-1 gateway configuration and firewall rules.  Feature added with M18.
 mcgw_export = False
 mcgw_export_filename = mcgw.json
-mcgw_fw_export = True
+mcgw_fw_export = False
 mcgw_fw_export_filename = mcgw_fw.json
 mcgw_static_routes_export = False
 mcgw_static_routes_export_filename = mcgw_static_routes.json
+
+# Export route aggregation lists and route configuration
+ral_export = True
+ral_export_filename = ral.json
+route_config_export = True
+route_config_export_filename = route_config.json
 
 # Filename for SDDC info - the base SDDC congfiguration from /vmc/api/orgs/*/sddc
 sddc_info_filename = sddc_info.json
@@ -149,8 +155,14 @@ mcgw_import = False
 mcgw_import_filename = mcgw.json
 mcgw_static_route_import = False
 mcgw_static_route_import_filename = mcgw_static_routes.json
-mcgw_fw_import = True
+mcgw_fw_import = False
 mcgw_fw_import_filename = mcgw_fw.json
+
+#Import Route Aggregation Lists and Route Configuration?
+ral_import = False
+ral_import_filename = ral.json
+route_config_import = True
+route_config_import_filename = route_config.json
 
 # Import the compute gateway networks?
 network_import  = False

--- a/config_ini/config.ini
+++ b/config_ini/config.ini
@@ -7,22 +7,22 @@ export_folder = json
 # sddcid_yyyy_mm_dd_hh-mm-ss_json.export.zip
 # c12fe3f4-515c-4859-ce45-2a25935ea251_2021_01_05_10-30-00_json.export.zip with the SDDC ID
 # 2021_01_05_10-30-00_json.export.zip without the SDDC ID
-append_sddc_id_to_zip = True
+append_sddc_id_to_zip = False
 
 # Export compute gateway groups filename
 # There is no True/False flag for this option because CGW groups are automatically exported with CGW settings
 cgw_groups_filename = cgw_groups.json
 
 # Export compute gateway settings?
-cgw_export = True
+cgw_export = False
 cgw_export_filename = cgw.json
 
 # Export the management gateway settings?
-mgw_export = True
+mgw_export = False
 mgw_export_filename = mgw.json
 
 # Export the networks configured on the compute gateway?
-network_export  = True
+network_export  = False
 network_export_filename = cgw-networks.json
 # Export DHCP static bindings for networks configured on the compute gateway?
 # This will significantly slow down the export process, only enable this if you use
@@ -30,27 +30,35 @@ network_export_filename = cgw-networks.json
 network_dhcp_static_binding_export = False
 
 # Export the list of public IP addresses?
-public_export = True
+public_export = False
 public_export_filename = public.json
 
 # Export the NAT rules, including Public IP addresses?
-nat_export = True
+nat_export = False
 nat_export_filename = natrules.json
 
 #Export VPN configuration?
-vpn_export = True
+vpn_export = False
 
 # Export service access?
-service_access_export = True
+service_access_export = False
 
 # Export the distributed firewall?
-dfw_export = True
+dfw_export = False
 dfw_export_filename = dfw.json
 dfw_detailed_export_filename = dfw_details.json
 
 # Export the NSX advanced firewall? This setting will have no effect if the
 # NSX advanced firewall add-on is not enabled in the source SDDC
-nsx_adv_fw_export       = False
+nsx_adv_fw_export = False
+
+# Export the multiple tier-1 gateway configuration and firewall rules.  Feature added with M18.
+mcgw_export = False
+mcgw_export_filename = mcgw.json
+mcgw_fw_export = True
+mcgw_fw_export_filename = mcgw_fw.json
+mcgw_static_routes_export = False
+mcgw_static_routes_export_filename = mcgw_static_routes.json
 
 # Filename for SDDC info - the base SDDC congfiguration from /vmc/api/orgs/*/sddc
 sddc_info_filename = sddc_info.json
@@ -58,7 +66,7 @@ sddc_info_filename = sddc_info.json
 sddc_info_hide_sensitive_data = True
 
 # Keep previous versions of the exported JSON files?
-export_history = True
+export_history = False
 # If export_history is set to True, how many previous zip files to keep before deleting the oldest file? -1 for unlimited
 max_export_history_files = 10
 # If export_history is true, do you want to purge the exported JSON files after they are zipped into the archive?
@@ -100,26 +108,26 @@ import_folder = json
 #
 # import_mode = live
 #  - Changes will be made to the destination SDDC
-import_mode = test
+import_mode = live
 
 # Script will warn, ask for a confirmation before continuing in live mode
 # Set this to false if you are absolutely sure you have your script configured correctly and want to run it automatically
-import_mode_live_warning = True
+import_mode_live_warning = False
 
 # Import services? Only disable this if you truly know what you are doing.
 # Firewall groups are dependent on Services. If you skip Services, Groups that are
 # dependent on those services will fail to import
-services_import = True
+services_import = False
 
 # Import groups? Only disable this if you truly know what you are doing.
 # Firewall rules are dependent on Groups. If you skip Groups, Firewall rules
 # dependent on those groups will fail to import. Both CGW and DFW rules are dependent
 # on Compute Groups
-compute_groups_import = True
-management_groups_import = True
+compute_groups_import = False
+management_groups_import = False
 
 # Import compute gateway settings?
-cgw_import = True
+cgw_import = False
 cgw_groups_filename = cgw_groups.json
 cgw_import_filename = cgw.json
 # Python regex match on CGW group display name, pipe-delimited. See README for examples.
@@ -128,7 +136,7 @@ cgw_groups_import_exclude_list =
 cgw_import_exclude_list =
 
 # Import the management gateway settings?
-mgw_import = True
+mgw_import = False
 mgw_groups_filename = mgw_groups.json
 mgw_import_filename = mgw.json
 # Python regex match on MGW group display name, pipe-delimited. See README for examples.
@@ -136,8 +144,16 @@ mgw_groups_import_exclude_list =
 # Python regex match on MGW rule display name, pipe-delimited. See README for examples.
 mgw_import_exclude_list =
 
+# Import additional Tier-1 Gateways and Firewall Policy/Rules?
+mcgw_import = False
+mcgw_import_filename = mcgw.json
+mcgw_static_route_import = False
+mcgw_static_route_import_filename = mcgw_static_routes.json
+mcgw_fw_import = True
+mcgw_fw_import_filename = mcgw_fw.json
+
 # Import the compute gateway networks?
-network_import  = True
+network_import  = False
 network_import_filename = cgw-networks.json
 # Python regex match on network display name, pipe-delimited. See README for examples.
 network_import_exclude_list = L2E_
@@ -149,25 +165,25 @@ network_import_max_networks = -1
 network_dhcp_static_binding_import = False
 
 # Import the list of public IP addresses?
-public_import = True
+public_import = False
 public_import_filename = public.json
 public_ip_old_new_filename = public_ip_old_new.json
 
 # Import the NAT rules across, alongside the public IP addresses?
-nat_import = True
+nat_import = False
 nat_import_filename = natrules.json
 
 # Import VPN configuration?
-vpn_import = True
+vpn_import = False
 
 # Automatically disable VPN tunnels when importing them
 vpn_disable_on_import = True
 
 # Import service access?
-service_access_import = True
+service_access_import = False
 
 # Import the distributed firewall?
-dfw_import = True
+dfw_import = False
 dfw_import_filename = dfw.json
 dfw_detailed_import_filename = dfw_details.json
 
@@ -178,7 +194,7 @@ dfw_detailed_import_filename = dfw_details.json
 # automatically enable the advanced firewall addon if you set
 # nsx_adv_fw_allow_enable to True
 nsx_adv_fw_allow_enable = False
-nsx_adv_fw_import       = False
+nsx_adv_fw_import = False
 
 
 # vCenter Import Options

--- a/sddc_import_export.py
+++ b/sddc_import_export.py
@@ -345,7 +345,7 @@ def main(args):
 
     if intent_name == "import-nsx":
         no_intent_found = False
-        print('Import mode:',ioObj.import_mode)
+        print('Import mode:', ioObj.import_mode)
 
         ioObj.getAccessToken(ioObj.dest_refresh_token)
         if (ioObj.access_token == ""):
@@ -530,6 +530,37 @@ def main(args):
                 print("CGW export error: {}".format(ioObj.lastJSONResponse))
         else:
             print("CGW export skipped.")
+        
+        if ioObj.mcgw_export is True:
+            print("Beginning Multi-T1 CGW export...")
+            retval = ioObj.export_mcgw_config()
+            if retval is True:
+                print("Multi-T1 CGW Config exported")
+            else:
+                print(f'Multi-T1 CGW export error: {ioObj.lastJSONResponse}')
+        else:
+            print("Multi-T1 CGW export skipped")
+
+        if ioObj.mcgw_static_routes_export is True:
+            print("Beginning Multi-T1 Static Routes Export")
+            retval = ioObj.export_mcgw_static_routes()
+            if retval is True:
+                print("Multi-T1 Static Routes exported")
+            else:
+                print(f"Multi-T1 static routes export error: {ioObj.lastJSONResponse}")
+        else:
+            print("Multi-T1 static routes export skipped")
+
+        if ioObj.mcgw_fw_export is True:
+            print("Beginning Multi-T1 North/South Firewall Policy and Rule Export")
+            retval = ioObj.export_mcgw_fw()
+
+            if retval is True:
+                print("Multi-T1 FW Policy and Rules exported")
+            else:
+                print(f"Multi-T1 FW Policy and Rules export error: {ioObj.lastJSONResponse}")
+        else:
+            print("Multi-T1 Firewall Policy and Rules export skipped")
 
         if ioObj.network_export is True:
             print("Beginning network segments export...")
@@ -757,6 +788,36 @@ def main(args):
             if ioObj.management_groups_import is False:
                 print('Management groups import is set to false, this can cause import errors if compute group objects are missing.')
             ioObj.importSDDCMGWRule()
+
+        if ioObj.mcgw_import is True:
+            print("Beginning Tier-1 Gateway import...")
+            if ioObj.services_import is False:
+                print('Service import is set to false, this can cause import errors if service objects are missing.')
+            if ioObj.compute_groups_import is False:
+                print('Compute groups import is set to false, this can cause import errors if compute group objects are missing.')
+            ioObj.import_mcgw()
+
+        if ioObj.mcgw_static_routes_import is True:
+            print("Beginning Tier-1 Gateway Static Route import...")
+            if ioObj.services_import is False:
+                print('Service import is set to false, this can cause import errors if service objects are missing.')
+            if ioObj.compute_groups_import is False:
+                print(
+                    'Compute groups import is set to false, this can cause import errors if compute group objects are missing.')
+            if ioObj.mcgw_import is False:
+                print('Tier-1 Gateway import is set to false, this can cause import error is Tier-1 Gateway objects are missing.')
+            ioObj.import_mcgw_static_routes()
+
+        if ioObj.mcgw_fw_import is True:
+            print('Beginning Tier-1 Gateway Firewall policy and rules import...')
+            if ioObj.services_import is False:
+                print('Service import is set to false, this can cause import errors if service objects are missing.')
+            if ioObj.compute_groups_import is False:
+                print(
+                    'Compute groups import is set to false, this can cause import errors if compute group objects are missing.')
+            if ioObj.mcgw_import is False:
+                print('Tier-1 Gateway import is set to false, this can cause import error is Tier-1 Gateway objects are missing.')
+            ioObj.import_mcgw_fw()
 
         if ioObj.dfw_import is True:
             print("Beginning DFW import...")

--- a/sddc_import_export.py
+++ b/sddc_import_export.py
@@ -562,6 +562,26 @@ def main(args):
         else:
             print("Multi-T1 Firewall Policy and Rules export skipped")
 
+        if ioObj.ral_export is True:
+            print('Beginning Route Aggegration list export')
+            retval = ioObj.export_ral()
+            if retval is True:
+                print("SDDC Route Aggregation list exported")
+            else:
+                print(f"SDDC Route Aggregation list export error: {ioObj.lastJSONResponse}")
+        else:
+            print("SDDC Route Aggregation list export skipped")
+
+        if ioObj.route_config_export is True:
+            print('Beginning SDDC route configuration export')
+            retval = ioObj.export_route_config()
+            if retval is True:
+                print("SDDC Route Configuration exported")
+            else:
+                print(f"SDDC Route Configuration export error: {ioObj.lastJSONResponse}")
+        else:
+            print("SDDC Route Configuration export skipped")
+
         if ioObj.network_export is True:
             print("Beginning network segments export...")
             retval = ioObj.exportSDDCCGWnetworks()
@@ -818,6 +838,16 @@ def main(args):
             if ioObj.mcgw_import is False:
                 print('Tier-1 Gateway import is set to false, this can cause import error is Tier-1 Gateway objects are missing.')
             ioObj.import_mcgw_fw()
+
+        if ioObj.ral_import is True:
+            print('Beginning import of SDDC Route Aggregation Lists...')
+            ioObj.import_ral()
+
+        if ioObj.route_config_import is True:
+            print('Beginning import of SDDC Route Configurations...')
+            if ioObj.ral_import is False:
+                print('Import of Route Configurations may be impacted by missing Route Aggregations lists')
+            ioObj.import_route_config()
 
         if ioObj.dfw_import is True:
             print("Beginning DFW import...")


### PR DESCRIPTION
Customers will be able to export Tier-1 gateway configurations, Tier-1 gateway static routes and Tier-1 gateway firewall policy and rules and subsequently import them to a new SDDC.

Signed-off-by: Chris White <whitech@vmware.com>